### PR TITLE
Fix label string, we need colon to be placed by pretty printing

### DIFF
--- a/src/main/java/lang/jimple/internal/Decompiler.java
+++ b/src/main/java/lang/jimple/internal/Decompiler.java
@@ -1213,7 +1213,7 @@ public class Decompiler {
 					}
 					else {
 						newLabels.put(labelIns.label, count);
-						labelIns.label = String.format("label%d:", count++);  // update the label to a more user friendly string
+						labelIns.label = String.format("label%d", count++);
 					}
 				}
 			}
@@ -1227,11 +1227,11 @@ public class Decompiler {
 			for(Statement s: instructions) {
 				if(s instanceof Statement.c_gotoStmt) {
 					Statement.c_gotoStmt g = (Statement.c_gotoStmt)s; 
-					g.target = newLabels.containsKey(g.target) ? String.format("label%d:", newLabels.get(g.target)) : g.target;
+					g.target = newLabels.containsKey(g.target) ? String.format("label%d", newLabels.get(g.target)) : g.target;
 				}
 				else if(s instanceof Statement.c_ifStmt) {
 					Statement.c_ifStmt i = (Statement.c_ifStmt)s;
-					i.target = newLabels.containsKey(i.target) ? String.format("label%d:", newLabels.get(i.target)) : i.target;
+					i.target = newLabels.containsKey(i.target) ? String.format("label%d", newLabels.get(i.target)) : i.target;
 				}
 			}
 		}


### PR DESCRIPTION
Label must be "textual" clean; we put the colon in the pretty printing module (because some labels are target and some are part of goto clasue).  